### PR TITLE
Feature/fix dc fips code

### DIFF
--- a/im3components/wrf_to_tell/README.md
+++ b/im3components/wrf_to_tell/README.md
@@ -3,7 +3,7 @@
 This page contains instructions for running the sequence of processing scripts that convert the meteorology from IM3's climate simulations using the Weather Research and Forecasting (WRF) model into input files ready for use in the Total ELectricity Load (TELL) model. The first step in the processing chain, *wrf_tell_counties.py*, spatially averages the gridded meteorology output from WRF into county-mean values. The output of that processing step is a series of .csv files (one for every hour processed) with the county-mean value of six meteorological variables: T2, Q2, U10, V10, SWDOWN, and GLW. The second step, *wrf_tell_balancing_authorities.py*, then takes these county-level hourly values and population-weights them into an annual time-series for each of the balancing authorities used in the TELL model. As the WRF data is currently stored on NERSC this processing chain is currently configured to work on that platform. For each step in the processing chain there is an associated slurm script that will launch the processing step on NERSC.
 
 ## To run the wrf_tell_counties.py step:
-1. Download and unzip the ancillary population and geolocation data needed to process the data: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6377756.svg)](https://doi.org/10.5281/zenodo.6377756)
+1. Download and unzip the ancillary population and geolocation data needed to process the data: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6407193.svg)](https://doi.org/10.5281/zenodo.6407193)
 
 2. Download the python scripts by making a local clone of the `develop` branch of the im3components repository.
 

--- a/im3components/wrf_to_tell/wrf_tell_balancing_authorities.py
+++ b/im3components/wrf_to_tell/wrf_tell_balancing_authorities.py
@@ -61,16 +61,7 @@ def wrf_to_tell_balancing_authorities(
         precisions = [2, 5, 2, 2, 2, 2]
 
     # Read the BA to county mapping file
-    ba_mapping_df = pd.read_csv(
-        balancing_authority_to_fips_file,
-        index_col=None,
-        header=0,
-    )[['county_fips', 'county_name', 'ba_number', 'ba_abbreviation']].rename(columns={
-        'county_fips': 'County_FIPS',
-        'county_name': 'County_Name',
-        'ba_number': 'BA_Number',
-        'ba_abbreviation': 'BA_Code',
-    }).drop_duplicates()
+    ba_mapping_df = pd.read_csv(balancing_authority_to_fips_file, index_col=None, header=0)
 
     # Read the county population by year file
     if is_historical:


### PR DESCRIPTION
Fixed an issue where the FIPS code for Washington, D.C. was 11000 in the historical population data and 11001 in the future population projections. This was causing anomalies in the wrf to tell balancing authorities processing step. Updated the Readme.md and wrf_tell_balancing_authorities.py files to reflect this change. Also updated to the new filename convention for the BA-to-county mapping file. Tested on NERSC with no issues.